### PR TITLE
Correct clone directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a little script to generate an HTML file from a RMarkdown file at the co
 
 Instructions:
 ```sh
-git clone  https://github.com/caromimo/knit.git ~./commands
+git clone https://github.com/caromimo/knit.git ~/.commands
 ```
 And then add the following line in your .bashrc file in your home directory:
 ```sh


### PR DESCRIPTION
This commit corrects the directory name so that it matches the directory
that is added to the search path in the last part of the readme.